### PR TITLE
Swap to shaded guava in common and core modules

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/ArrowSchemaUtil.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/ArrowSchemaUtil.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg.arrow;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
+import com.google.common.shaded.collect.ImmutableList;
+import com.google.common.shaded.collect.ImmutableMap;
+import com.google.common.shaded.collect.Lists;
 import java.util.List;
 import java.util.Map;
 import org.apache.arrow.vector.types.DateUnit;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg.arrow.vectorized;
 
-import com.google.common.base.Preconditions;
+import com.google.common.shaded.base.Preconditions;
 import java.util.Map;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.BigIntVector;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg.arrow.vectorized.parquet;
 
-import com.google.common.base.Preconditions;
+import com.google.common.shaded.base.Preconditions;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.parquet.bytes.ByteBufferInputStream;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedColumnIterator.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedColumnIterator.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg.arrow.vectorized.parquet;
 
-import com.google.common.base.Preconditions;
+import com.google.common.shaded.base.Preconditions;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.iceberg.arrow.vectorized.NullabilityHolder;

--- a/build.gradle
+++ b/build.gradle
@@ -131,8 +131,14 @@ project(':iceberg-relocate-external-dependencies') {
       include 'NOTICE'
     }
 
+    dependencies {
+      exclude(dependency('com.github.stephenc.findbugs:findbugs-annotations'))
+      exclude(dependency('org.slf4j:slf4j-api'))
+      exclude(dependency('org.checkerframework:checker-qual'))
+    }
+
     relocate 'com.google.common', 'com.google.common.shaded'
-    
+
     minimize()
   }
 }
@@ -145,7 +151,11 @@ project(':iceberg-api') {
   }
 }
 
-project(':iceberg-common') {}
+project(':iceberg-common') {
+  dependencies {
+    compile project(path: ':iceberg-relocate-external-dependencies', configuration: 'shadow')
+  }
+}
 
 project(':iceberg-core') {
   dependencies {

--- a/common/src/main/java/org/apache/iceberg/common/DynClasses.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynClasses.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg.common;
 
-import com.google.common.base.Joiner;
+import com.google.common.shaded.base.Joiner;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
@@ -19,8 +19,8 @@
 
 package org.apache.iceberg.common;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
+import com.google.common.shaded.base.Preconditions;
+import com.google.common.shaded.base.Throwables;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;

--- a/common/src/main/java/org/apache/iceberg/common/DynFields.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynFields.java
@@ -19,11 +19,12 @@
 
 package org.apache.iceberg.common;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Sets;
+
+import com.google.common.shaded.base.Joiner;
+import com.google.common.shaded.base.MoreObjects;
+import com.google.common.shaded.base.Preconditions;
+import com.google.common.shaded.base.Throwables;
+import com.google.common.shaded.collect.Sets;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.security.AccessController;

--- a/common/src/main/java/org/apache/iceberg/common/DynMethods.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynMethods.java
@@ -19,8 +19,8 @@
 
 package org.apache.iceberg.common;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
+import com.google.common.shaded.base.Preconditions;
+import com.google.common.shaded.base.Throwables;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
+import com.google.common.shaded.collect.ImmutableMap;
+import com.google.common.shaded.collect.Iterables;
+import com.google.common.shaded.collect.Sets;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -19,8 +19,8 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
+import com.google.common.shaded.collect.ImmutableMap;
+import com.google.common.shaded.collect.Sets;
 import java.util.Collection;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ResidualEvaluator;

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
+import com.google.common.shaded.collect.ImmutableList;
+import com.google.common.shaded.collect.ImmutableMap;
+import com.google.common.shaded.collect.Iterables;
 import java.io.IOException;
 import java.util.Collection;
 import org.apache.iceberg.avro.Avro;

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.shaded.collect.ImmutableMap;
 import java.util.Collection;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.events.ScanEvent;

--- a/core/src/main/java/org/apache/iceberg/BaseCombinedScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseCombinedScanTask.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
+import com.google.common.shaded.base.Joiner;
+import com.google.common.shaded.base.MoreObjects;
+import com.google.common.shaded.collect.ImmutableList;
 import java.util.Collection;
 import java.util.List;
 

--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
+import com.google.common.shaded.annotations.VisibleForTesting;
+import com.google.common.shaded.base.MoreObjects;
+import com.google.common.shaded.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.shaded.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.encryption.EncryptionManager;

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -19,11 +19,11 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import com.google.common.shaded.base.MoreObjects;
+import com.google.common.shaded.base.Objects;
+import com.google.common.shaded.collect.ImmutableList;
+import com.google.common.shaded.collect.Iterables;
+import com.google.common.shaded.collect.Lists;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -19,11 +19,11 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
+import com.google.common.shaded.base.MoreObjects;
+import com.google.common.shaded.base.Preconditions;
+import com.google.common.shaded.collect.FluentIterable;
+import com.google.common.shaded.collect.ImmutableMap;
+import com.google.common.shaded.collect.Sets;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
+import com.google.common.shaded.collect.ImmutableList;
+import com.google.common.shaded.collect.ImmutableMap;
+import com.google.common.shaded.collect.Sets;
 import java.util.Collection;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ResidualEvaluator;

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.shaded.base.Preconditions;
+import com.google.common.shaded.collect.ImmutableList;
+import com.google.common.shaded.collect.ImmutableMap;
 import java.util.Collection;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -19,10 +19,10 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import com.google.common.shaded.base.MoreObjects;
+import com.google.common.shaded.collect.ImmutableMap;
+import com.google.common.shaded.collect.Lists;
+import com.google.common.shaded.collect.Maps;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.MoreObjects;
+import com.google.common.shaded.base.MoreObjects;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaUtil;

--- a/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.collect.Lists;
+import com.google.common.shaded.base.MoreObjects;
+import com.google.common.shaded.base.Objects;
+import com.google.common.shaded.collect.Lists;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;

--- a/core/src/main/java/org/apache/iceberg/GenericPartitionFieldSummary.java
+++ b/core/src/main/java/org/apache/iceberg/GenericPartitionFieldSummary.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.MoreObjects;
+import com.google.common.shaded.base.MoreObjects;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -19,12 +19,12 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import com.google.common.shaded.base.Preconditions;
+import com.google.common.shaded.collect.FluentIterable;
+import com.google.common.shaded.collect.ImmutableMap;
+import com.google.common.shaded.collect.Iterables;
+import com.google.common.shaded.collect.Lists;
+import com.google.common.shaded.collect.Sets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
+import com.google.common.shaded.collect.ImmutableList;
+import com.google.common.shaded.collect.ImmutableMap;
+import com.google.common.shaded.collect.Sets;
 import java.util.Collection;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ResidualEvaluator;

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.shaded.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.function.Function;
 import org.apache.iceberg.expressions.Expression;

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -19,15 +19,15 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
+import com.google.common.shaded.base.MoreObjects;
+import com.google.common.shaded.base.Objects;
+import com.google.common.shaded.base.Preconditions;
+import com.google.common.shaded.collect.ImmutableList;
+import com.google.common.shaded.collect.ImmutableMap;
+import com.google.common.shaded.collect.Iterables;
+import com.google.common.shaded.collect.Lists;
+import com.google.common.shaded.collect.Maps;
+import com.google.common.shaded.collect.Sets;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/core/src/test/java/org/apache/iceberg/TestWapWorkflow.java
+++ b/core/src/test/java/org/apache/iceberg/TestWapWorkflow.java
@@ -19,8 +19,8 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Streams;
+import com.google.common.shaded.collect.Iterables;
+import com.google.common.shaded.collect.Streams;
 import org.apache.iceberg.exceptions.CherrypickAncestorCommitException;
 import org.apache.iceberg.exceptions.DuplicateWAPCommitException;
 import org.apache.iceberg.exceptions.ValidationException;


### PR DESCRIPTION
Had to exclude a few dependencies from the `relocate-external-dependencies` because of runtime class uniqueness issues as it the module pulls in a few dependencies from the shared project-wide dependencies