### PR TITLE
Fix date and timestamp conversion

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
@@ -42,6 +42,10 @@ public class DateTimeUtil {
     return (int) ChronoUnit.DAYS.between(EPOCH_DAY, date);
   }
 
+  public static int daysFromInstant(Instant instant) {
+    return (int) ChronoUnit.DAYS.between(EPOCH, instant.atOffset(ZoneOffset.UTC));
+  }
+
   public static LocalTime timeFromMicros(long microFromMidnight) {
     return LocalTime.ofNanoOfDay(microFromMidnight * 1000);
   }
@@ -52,6 +56,10 @@ public class DateTimeUtil {
 
   public static LocalDateTime timestampFromMicros(long microsFromEpoch) {
     return ChronoUnit.MICROS.addTo(EPOCH, microsFromEpoch).toLocalDateTime();
+  }
+
+  public static long microsFromInstant(Instant instant) {
+    return ChronoUnit.MICROS.between(EPOCH, instant.atOffset(ZoneOffset.UTC));
   }
 
   public static long microsFromTimestamp(LocalDateTime dateTime) {


### PR DESCRIPTION
This fixes problems with Date and Timestamp conversion:
* Dates must be converted to days from epoch, not micros
* Timestamp#toLocalDate converts with respect to the timestamp's time zone instead of UTC so the date is inaccurate
* Timestamp access was corrupting the timestamp value and discarding microseconds ([HIVE-19726](https://issues.apache.org/jira/browse/HIVE-19726)) so this accesses the value directly

This converts directly and fixes the tests using Iceberg literals. The timestamp test was updated to create a Timestamp to pass into Hive directly from a known value in microseconds because parsing is dependent on the local zone. That dependency is okay when Hive is running, but we need a Timestamp with a known UTC instant for the test.