### PR TITLE
Projection pushdown changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -473,6 +473,8 @@ project(':iceberg-mr') {
     testCompile("org.apache.hive:hive-service") {
       exclude group: 'org.apache.hive', module: 'hive-exec'
     }
+    testCompile("org.apache.tez:tez-dag")
+    testCompile("org.apache.tez:tez-mapreduce")
   }
 
   test {
@@ -538,6 +540,7 @@ if (jdkVersion == '8') {
         exclude group: 'org.apache.hive', module: 'hive-exec'
       }
       testCompile("org.apache.tez:tez-dag:0.9.1")
+      testCompile("org.apache.tez:tez-mapreduce:0.9.1")
     }
 
     test {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
@@ -49,8 +49,6 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
 
   private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergInputFormat.class);
 
-  private String[] selectedColumns;
-
   @Override
   public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
     // Convert Hive filter to Iceberg filter
@@ -67,7 +65,7 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
       }
     }
 
-    selectedColumns = ColumnProjectionUtils.getReadColumnNames(job);
+    String[] selectedColumns = ColumnProjectionUtils.getReadColumnNames(job);
     job.setStrings(InputFormatConfig.SELECTED_COLUMNS, selectedColumns);
 
     String location = job.get(InputFormatConfig.TABLE_LOCATION);
@@ -79,6 +77,7 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
   @Override
   public RecordReader<Void, Container<Record>> getRecordReader(InputSplit split, JobConf job,
                                                                Reporter reporter) throws IOException {
+    String[] selectedColumns = ColumnProjectionUtils.getReadColumnNames(job);
     job.setStrings(InputFormatConfig.SELECTED_COLUMNS, selectedColumns);
     return super.getRecordReader(split, job, reporter);
   }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
@@ -20,6 +20,8 @@
 package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -110,13 +112,28 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
 
   public abstract TestTables testTables(Configuration conf, TemporaryFolder tmp) throws IOException;
 
-  @Parameters(name = "fileFormat={0}")
-  public static Iterable<FileFormat> fileFormats() {
-    return ImmutableList.of(FileFormat.PARQUET, FileFormat.ORC, FileFormat.AVRO);
+  @Parameters(name = "fileFormat={0}, engine={1}")
+  public static Collection<Object[]> parameters() {
+    Collection<Object[]> testParams = new ArrayList<>();
+    testParams.add(new Object[] { FileFormat.PARQUET, "mr" });
+    testParams.add(new Object[] { FileFormat.ORC, "mr" });
+    testParams.add(new Object[] { FileFormat.AVRO, "mr" });
+
+    // include Tez tests only for Java 8
+    String javaVersion = System.getProperty("java.specification.version");
+    if (javaVersion.equals("1.8")) {
+      testParams.add(new Object[] { FileFormat.PARQUET, "tez" });
+      testParams.add(new Object[] { FileFormat.ORC, "tez" });
+      testParams.add(new Object[] { FileFormat.AVRO, "tez" });
+    }
+    return testParams;
   }
 
-  @Parameter
+  @Parameter(0)
   public FileFormat fileFormat;
+
+  @Parameter(1)
+  public String executionEngine;
 
   @BeforeClass
   public static void beforeClass() {
@@ -137,6 +154,9 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
     for (Map.Entry<String, String> property : testTables.properties().entrySet()) {
       shell.setHiveSessionValue(property.getKey(), property.getValue());
     }
+    shell.setHiveSessionValue("hive.execution.engine", executionEngine);
+    shell.setHiveSessionValue("hive.jar.directory", temp.getRoot().getAbsolutePath());
+    shell.setHiveSessionValue("tez.staging-dir", temp.getRoot().getAbsolutePath());
   }
 
   @After

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
@@ -171,6 +171,12 @@ public class TestHiveShell {
     hiveConf.setLongVar(HiveConf.ConfVars.HIVECOUNTERSPULLINTERVAL, 1L);
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVESTATSAUTOGATHER, false);
 
+    // Resource configuration
+    hiveConf.setInt("mapreduce.map.memory.mb", 1024);
+
+    // Tez configuration
+    hiveConf.setBoolean("tez.local.mode", true);
+
     return hiveConf;
   }
 }

--- a/versions.props
+++ b/versions.props
@@ -23,3 +23,5 @@ junit:junit = 4.12
 org.mockito:mockito-core = 1.10.19
 org.apache.hive:hive-exec = 2.3.7
 org.apache.hive:hive-service = 2.3.7
+org.apache.tez:tez-dag = 0.8.4
+org.apache.tez:tez-mapreduce = 0.8.4


### PR DESCRIPTION
I had to cherry-pick e576c04 from apache/master as well to make this work, but you can ignore the changes in that commit.
Please focus on the other two commits :) MR was relatively easy to fix (96fd4dd), while Tez is more complicated and needs an upstream fix (TEZ-4248) to work when vectorization is enabled. Temporarily for now, vectorized Tez executions are disabled (fc1411d), and once TEZ-4248 has shipped in the next 0.9.3 release, we can upgrade to that version and remove the assertion.